### PR TITLE
Multilingual Application Toolkit extension installation troubleshooting

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -33,9 +33,9 @@ jobs:
     - uses: ./
       name: Test installing nanoFramework extension
       with: 
-        packagename: 'nanoframework.nanoFramework-VS2019-Extension'
+        packageName: 'nanoframework.nanoFramework-VS2019-Extension'
 
     - name: Test installing multilingual app toolkit extension
       uses: ./
       with:
-        packagename: 'dts-publisher.mat2022'
+        packageName: 'dts-publisher.mat2022'

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -13,10 +13,9 @@ env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
   
 jobs: 
-  test-install-vsix:
-    name: Test local install-vsix Package
+  test-install-nanoFramework-extension:
+    name: Test installing the nanoFramework extension
     runs-on: windows-latest
-    
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -35,7 +34,23 @@ jobs:
       with: 
         packageName: 'nanoframework.nanoFramework-VS2019-Extension'
 
+  test-install-mat-extension:
+    name: Test installation of the MAT framework extension
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2.0.0
+
     - name: Test installing multilingual app toolkit extension
+      id: test-vsix
       uses: ./
       with:
         packageName: 'dts-publisher.mat2022'
+        monitorProcess: true
+
+    - name: Confirm output of logs directory match string
+      run: |
+        Write-Host "GitHub action returned output: ${{ steps.test-vsix.outputs.logsPathMatch }}"

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -34,3 +34,8 @@ jobs:
       name: Test installing nanoFramework extension
       with: 
         packagename: 'nanoframework.nanoFramework-VS2019-Extension'
+
+    - name: Test installing multilingual app toolkit extension
+      uses: ./
+      with:
+        packagename: 'dts-publisher.mat2022'

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -9,12 +9,14 @@ on:
       - '!.gitignore'
       - '!*.md'
       - '!LICENSE'
+  workflow_dispatch:
+
 env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
   
 jobs: 
-  test-install-nanoFramework-extension:
-    name: Test installing the nanoFramework extension
+  nanoFramework:
+    name: Install nanoFramework extension
     runs-on: windows-latest
     steps:
     - name: Checkout
@@ -22,20 +24,31 @@ jobs:
 
     - name: Setup msbuild
       uses: microsoft/setup-msbuild@v2.0.0
-       
-    - name: Show Visual Studio locator information
-      run: vswhere.exe
 
-    - name: Setup nuget
-      uses: nuget/setup-nuget@v2
+    # - name: Setup nuget
+    #   uses: nuget/setup-nuget@v2
       
     - uses: ./
-      name: Test installing nanoFramework extension
+      id: install-vsix
       with: 
         packageName: 'nanoframework.nanoFramework-VS2019-Extension'
+        verboseLogOutput: true
+        monitorProcess: true
 
-  test-install-mat-extension:
-    name: Test installation of the MAT framework extension
+    - name: Test output
+      if: always()
+      run: |
+        Write-Host "Output: ${{ steps.install-vsix.outputs.logsPathMatch }}
+
+    - name: Capture logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: VSIXInstaller-Logs
+        path: ${{ steps.install-vsix.outputs.logsPathMatch }}
+
+  multilingual-app-toolkit:
+    name: Install Multilingual Application Toolkit extension
     runs-on: windows-latest
     steps:
     - name: Checkout
@@ -45,12 +58,20 @@ jobs:
       uses: microsoft/setup-msbuild@v2.0.0
 
     - name: Test installing multilingual app toolkit extension
-      id: test-vsix
+      id: install-vsix
       uses: ./
       with:
         packageName: 'dts-publisher.mat2022'
-        monitorProcess: true
+        verboseLogOutput: true
+
+    - name: Capture logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: VSIXInstaller-Logs
+        path: ${{ steps.install-vsix.outputs.logsPathMatch }}
 
     - name: Confirm output of logs directory match string
+      if: always()
       run: |
-        Write-Host "GitHub action returned output: ${{ steps.test-vsix.outputs.logsPathMatch }}"
+        Write-Host "GitHub action returned output: ${{ steps.install-vsix.outputs.logsPathMatch }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#VSCode workspace files
+*.code-workspace

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "PowerShell: Launch Current File",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "args": []
+        },
+        {
+            "name": "Flat script launch",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "args": ["-PackageName 'dts-publisher.mat2022'", "-Debug"] //"-OutputDetailedInfo True",
+        }
+    ]
+}

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,26 @@
 name: 'Install a Visual Studio Extension' 
 description: 'Download the latest extension version and install in Visual Studio'
 inputs:
-  packagename: 
+  packageName: 
     description:  'Package names from the Visual Studio Marketplace URL itemName parameter'
     required: true
+  monitorProcess:
+    description:  'Regularly print out basic information of the extension Process object (CPU, etc.)'
+    default: false
+  verboseLogOutput:
+    description:  'Print out to console much more logged information than normal.'
+    default: false
+outputs:
+  logsPathMatch:
+    description: 'Path on the runner, with wildcards, to match all associated log files.'
+    value: ${{ steps.vsix.outputs.logs-path-match }}
 runs:
   using: "composite"
   steps:
     - id: vsix
       shell: pwsh
-      run: .\install-vsix.ps1 ${{ inputs.packagename }}
+      run: |
+        .\install-vsix.ps1 \
+          -MonitorProcessInfo ${{ inputs.monitorProcess }} \
+          -OutputDetailedInfo ${{ inputs.verboseLogOutput }} \
+          -PackageName ${{ inputs.packageName }}

--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,20 @@ inputs:
 outputs:
   logsPathMatch:
     description: 'Path on the runner, with wildcards, to match all associated log files.'
-    value: ${{ steps.vsix.outputs.logs-path-match }}
+    value: ${{ steps.gen-log-path.outputs.path }}
 runs:
   using: "composite"
   steps:
+    - id: gen-log-path
+      shell: pwsh
+      run: |
+        [System.Environment]::SetEnvironmentVariable("GITHUB_OUTPUT","path=$($env:TEMP)\dd_*.log")
+        Write-Host "Updated output to $($env:GITHUB_OUTPUT)"
+        Write-Host "verboseLogOutput from expression: ${{ inputs.verboseLogOutput }}"
     - id: vsix
       shell: pwsh
       run: |
-        .\install-vsix.ps1 \
-          -MonitorProcessInfo ${{ inputs.monitorProcess }} \
-          -OutputDetailedInfo ${{ inputs.verboseLogOutput }} \
-          -PackageName ${{ inputs.packageName }}
+        Set-PSRepository PSGallery -InstallationPolicy Trusted # Prepare environment for installing a package
+        .\install-vsix.ps1 -PackageName ${{ inputs.packageName }} `
+          ${{ (inputs.monitorProcess == 'true') && '-MonitorProcessInfo' || '' }} `
+          ${{ (inputs.verboseLogOutput == 'true') && '-OutputDetailedInfo' || '' }}

--- a/install-vsix.ps1
+++ b/install-vsix.ps1
@@ -1,9 +1,11 @@
-Param
-(
-    [Parameter(Mandatory=$true,
-                ValueFromRemainingArguments=$true)]
+param (
+    [Parameter()]
+    $MonitorProcessInfo = $false,
+    [Parameter()]
+    $OutputDetailedInfo = $false,
+    [Parameter(Mandatory = $true,
+        ValueFromRemainingArguments = $true)]
     [ValidateNotNullOrEmpty()]
-    [String]
     $PackageName
 )
 

--- a/install-vsix.ps1
+++ b/install-vsix.ps1
@@ -48,7 +48,7 @@ if (-Not (Test-Path $VsixLocation)) {
 Write-Host "VSInstallDir is $($VSInstallDir)"
 Write-Host "VsixLocation is $($VsixLocation)"
 Write-Host "Installing $PackageName..."
-Start-Process -Filepath "$($VSInstallDir)\VSIXInstaller" -ArgumentList "/q /a $($VsixLocation)" -Wait -PassThru
+$proc = Start-Process -Filepath "$($VSInstallDir)\VSIXInstaller" -ArgumentList "/q $($VsixLocation)" -PassThru
 
 Write-Host "Cleanup..."
 rm $VsixLocation

--- a/install-vsix.ps1
+++ b/install-vsix.ps1
@@ -9,11 +9,15 @@ param (
     $PackageName
 )
 
+$ErrorActionPreference = "Stop"
+
 $baseProtocol = "https:"
 $baseHostName = "marketplace.visualstudio.com"
 
 $Uri = "$($baseProtocol)//$($baseHostName)/items?itemName=$PackageName"
-$VsixLocation = "$($env:Temp)\$([guid]::NewGuid()).vsix"
+$TempGuid = [guid]::NewGuid()
+$VsixDir = $env:TEMP
+$VsixLocation = "$($VsixDir)\$($TempGuid).vsix"
 
 $VSInstallDir = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service"
 

--- a/install-vsix.ps1
+++ b/install-vsix.ps1
@@ -47,10 +47,92 @@ if (-Not (Test-Path $VsixLocation)) {
 }
 Write-Host "VSInstallDir is $($VSInstallDir)"
 Write-Host "VsixLocation is $($VsixLocation)"
+
+Write-Host "Initializing log file monitoring..."
+Install-Module -Name FSWatcherEngineEvent
+# Date format is yyyyMMddHHmmss
+$LogFileNameIncludes = @( "dd_VSIXInstaller_*" )
+if ($OutputDetailedInfo) { $LogFileNameIncludes += "dd_setup*.log" }
+else { $LogFileNameIncludes += "dd_setup_*_errors.log" }
+$LogFileReaders = @{}
+
+function FSWatcherEventAction($FSWEvent) {
+    $FileName = $FSWEvent.MessageData.Name
+    Write-Debug "File event: $($FileName)"
+
+    foreach ($item In $LogFileNameIncludes) {
+        if (($FileName -like $item) -and (!$LogFileReaders.ContainsKey($FileName))) {
+            Write-Debug "Returning new matching and unopened file."
+            return $FileName
+        }
+    }
+}
+
+Write-Host "Connecting file monitor event handler..."
+# https://github.com/wgross/fswatcher-engine-event/blob/main/README.md
+$WatcherJob = New-FileSystemWatcher -SourceIdentifier "VSIXLogFileMonitor" -Path $VsixDir -Filter "dd_*.log" -Action { FSWatcherEventAction $event }
+
 Write-Host "Installing $PackageName..."
 $proc = Start-Process -Filepath "$($VSInstallDir)\VSIXInstaller" -ArgumentList "/q $($VsixLocation)" -PassThru
 
-Write-Host "Cleanup..."
-rm $VsixLocation
+while ($proc.HasExited -eq $false) {
+    # Check if the watcher job has encountered an error and pass it along
+    if ($WatcherJob.JobStateInfo.State.HasFlag([System.Management.Automation.JobState]::Failed)) {
+        throw $WatcherJob.Error[0].Exception
+    }
 
-Write-Host "Installation of $PackageName complete!"
+    # Check if new file to watch was returned
+    $watcherJobOut = Receive-Job -Job $WatcherJob
+    if ($watcherJobOut) {
+        Write-Debug "Received output from watcher job!" ; $watcherJobOut
+        # Sometimes an array might be returned (works for single objects too)
+        $watcherJobOut | ForEach-Object {
+            if (!($LogFileReaders.ContainsKey($_))) {
+                # Open file for reading, using a workaround that gives us the most permissive sharing & access.
+                $LogFileReaders[$_] = New-Object System.IO.StreamReader ( New-Object System.IO.FileStream(
+                        "$($VsixDir)\$($_)", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite))
+                Write-Host "Opened $($_) for reading."
+            }
+            else { Write-Debug "Attempted to open a duplicate streamreader!"}
+        }
+    }
+
+    # Iterate through all streamreaders and read-out to the end of the buffer
+    $LogFileReaders.GetEnumerator() | ForEach-Object {
+        if (!$_.Value.EndOfStream) {
+            Write-Host "[$($_.Key)] bytes $($_.Value.BaseStream.Position) to $($_.Value.BaseStream.Length)"
+            while (!$_.Value.EndOfStream) { Write-Host $_.Value.ReadToEnd() }
+            Write-Host "[End of stream]`r`n"
+        }
+    }
+
+    if ($MonitorProcessInfo) { Write-Host ($proc | Format-Table | Out-String) }
+
+    Start-Sleep 1
+}
+
+Write-Host "Process exited."
+
+Write-Host "Cleanup..."
+
+Remove-FileSystemWatcher -SourceIdentifier "VSIXLogFileMonitor"
+Remove-Item $VsixLocation
+$LogFileReaders.GetEnumerator() | ForEach-Object {
+    Write-Debug "Closing file $($_.Key)"
+    $_.Value.Close()
+}
+
+if ($proc.ExitCode -ne 0) {
+    Write-Host "Error encountered: $($proc.ExitCode)"
+    Write-Host (Select-String -Path $env:temp\dd_setup_*_errors.log -Pattern "^.*Exception.*$")
+}
+else {
+    Write-Host "Installation of $PackageName complete!"
+}
+
+if ($env:GITHUB_WORKSPACE) {
+    exit $proc.ExitCode
+}
+else {
+    Write-Host "Simulated exit code $($proc.ExitCode)"
+}

--- a/install-vsix.ps1
+++ b/install-vsix.ps1
@@ -18,6 +18,7 @@ $Uri = "$($baseProtocol)//$($baseHostName)/items?itemName=$PackageName"
 $TempGuid = [guid]::NewGuid()
 $VsixDir = $env:TEMP
 $VsixLocation = "$($VsixDir)\$($TempGuid).vsix"
+Write-Output "logs-path-match=$($VsixDir)\dd_*.log" >> $env:GTHUB_OUTPUT
 
 $VSInstallDir = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service"
 

--- a/install-vsix.ps1
+++ b/install-vsix.ps1
@@ -1,10 +1,9 @@
 param (
-    [Parameter()]
+    [Switch]
     $MonitorProcessInfo = $false,
-    [Parameter()]
+    [Switch]
     $OutputDetailedInfo = $false,
-    [Parameter(Mandatory = $true,
-        ValueFromRemainingArguments = $true)]
+    [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     $PackageName
 )
@@ -16,10 +15,8 @@ $baseHostName = "marketplace.visualstudio.com"
 
 $Uri = "$($baseProtocol)//$($baseHostName)/items?itemName=$PackageName"
 $TempGuid = [guid]::NewGuid()
-$VsixDir = $env:TEMP
+$VsixDir = $env:TEMP # Always do our work in temp dir. Also where logs are located.
 $VsixLocation = "$($VsixDir)\$($TempGuid).vsix"
-Write-Output "logs-path-match=$($VsixDir)\dd_*.log" >> $env:GTHUB_OUTPUT
-
 $VSInstallDir = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service"
 
 if (-Not $VSInstallDir) {
@@ -50,33 +47,31 @@ Write-Host "VSInstallDir is $($VSInstallDir)"
 Write-Host "VsixLocation is $($VsixLocation)"
 
 Write-Host "Initializing log file monitoring..."
-Install-Module -Name FSWatcherEngineEvent
+# https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-powershell#installing-dependencies
+Install-Module FSWatcherEngineEvent
 # Date format is yyyyMMddHHmmss
 $LogFileNameIncludes = @( "dd_VSIXInstaller_*" )
 if ($OutputDetailedInfo) { $LogFileNameIncludes += "dd_setup*.log" }
 else { $LogFileNameIncludes += "dd_setup_*_errors.log" }
 $LogFileReaders = @{}
 
-function FSWatcherEventAction($FSWEvent) {
-    $FileName = $FSWEvent.MessageData.Name
-    Write-Debug "File event: $($FileName)"
+Write-Host "Connecting file monitor event handler..."
+# https://github.com/wgross/fswatcher-engine-event/blob/main/README.md
+$WatcherJob = New-FileSystemWatcher -SourceIdentifier "VSIXLogFileMonitor" -Path $env:TEMP -Filter "dd_*.log" -Action {
+    $FileName = $event.MessageData.Name
+    Write-Host "File event: $([System.IO.WatcherChangeTypes]($event.MessageData.ChangeType).ToString()) $($FileName)"
 
     foreach ($item In $LogFileNameIncludes) {
         if (($FileName -like $item) -and (!$LogFileReaders.ContainsKey($FileName))) {
-            Write-Debug "Returning new matching and unopened file."
             return $FileName
         }
     }
-}
-
-Write-Host "Connecting file monitor event handler..."
-# https://github.com/wgross/fswatcher-engine-event/blob/main/README.md
-$WatcherJob = New-FileSystemWatcher -SourceIdentifier "VSIXLogFileMonitor" -Path $VsixDir -Filter "dd_*.log" -Action { FSWatcherEventAction $event }
+ }
 
 Write-Host "Installing $PackageName..."
 $proc = Start-Process -Filepath "$($VSInstallDir)\VSIXInstaller" -ArgumentList "/q $($VsixLocation)" -PassThru
 
-while ($proc.HasExited -eq $false) {
+while (!$proc.HasExited) {
     # Check if the watcher job has encountered an error and pass it along
     if ($WatcherJob.JobStateInfo.State.HasFlag([System.Management.Automation.JobState]::Failed)) {
         throw $WatcherJob.Error[0].Exception
@@ -85,7 +80,7 @@ while ($proc.HasExited -eq $false) {
     # Check if new file to watch was returned
     $watcherJobOut = Receive-Job -Job $WatcherJob
     if ($watcherJobOut) {
-        Write-Debug "Received output from watcher job!" ; $watcherJobOut
+        Write-Host "Received output from watcher job!" ; $watcherJobOut
         # Sometimes an array might be returned (works for single objects too)
         $watcherJobOut | ForEach-Object {
             if (!($LogFileReaders.ContainsKey($_))) {
@@ -109,7 +104,7 @@ while ($proc.HasExited -eq $false) {
 
     if ($MonitorProcessInfo) { Write-Host ($proc | Format-Table | Out-String) }
 
-    Start-Sleep 1
+    Start-Sleep 3
 }
 
 Write-Host "Process exited."
@@ -131,9 +126,9 @@ else {
     Write-Host "Installation of $PackageName complete!"
 }
 
-if ($env:GITHUB_WORKSPACE) {
+# if ($env:GITHUB_WORKSPACE) {
     exit $proc.ExitCode
-}
-else {
-    Write-Host "Simulated exit code $($proc.ExitCode)"
-}
+# }
+# else {
+#     Write-Host "Simulated exit code $($proc.ExitCode)"
+# }


### PR DESCRIPTION
The Multilingual Application Toolkit extension (ID `dts-publisher.mat2022`) takes a long time to install for people using GitHub-hosted runners. Improvements are being made to troubleshoot and fix the issue.

# See also
- microcompiler/install-vsix/issues/1
- Stehfyn/cs474/issues/4
- https://github.com/actions/runner-images/issues/7389